### PR TITLE
Fix clamp variable name

### DIFF
--- a/io_scene_x3d/import_x3d.py
+++ b/io_scene_x3d/import_x3d.py
@@ -2816,9 +2816,9 @@ def appearance_LoadTexture(tex_node, ancestry, node):
 
     if bpyima:  # Loading can still fail
         repeat_s = tex_node.getFieldAsBool('repeatS', True, ancestry)
-        bpyima.use_clight_x = not repeat_s
+        bpyima.use_clamp_x = not repeat_s
         repeat_t = tex_node.getFieldAsBool('repeatT', True, ancestry)
-        bpyima.use_clight_y = not repeat_t
+        bpyima.use_clamp_y = not repeat_t
 
         # Update the desc-based cache
         if desc:


### PR DESCRIPTION
This change fixes a bug introduced by:

https://github.com/sobotka/blender-addons/commit/6aa8e130eff59059886e203ff95221609f63b222

Which renamed many variables from "lamp" to "light" and
incorrectly renamed "clamp" to "clight" as part of a
search and replace.